### PR TITLE
Remove sapphire-plugin-modal-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ choose either the regular badge or the flat one.
 - [@kaname-png/plugin-api-jwt](https://github.com/kaname-png/neko-plugins/tree/main/packages/api-jwt): Plugin for
   [`@sapphire/framework`](https://github.com/sapphiredev/framework) to use [JSON Web Tokens](https://jwt.io) instead of
   [HttpOnly Secure Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
-- [sapphire-plugin-modal-commands](https://github.com/MajesticString/sapphire-plugin-modal-commands#readme): Plugin for
-  [`@sapphire/framework`](https://github.com/sapphiredev/framework) that allows modal submits to be handled in the
-  corresponding command.
 - [@kaname-png/plugin-subcommands-advanced](https://github.com/kaname-png/neko-plugins/tree/main/packages/subcommands-advanced#readme):
   Plugin for [`@sapphire/framework`](https://github.com/sapphiredev/framework) to create and register subcommands using
   decorators and/or advanced class structures.


### PR DESCRIPTION
I stopped maintaining this plugin a while ago, and there are better native ways of handling modals (`<CommandInteraction>.awaitModalSubmit`)